### PR TITLE
fix: $secureRenderer and $jsonHelper not defined in Magento 2.3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "ImageKit 2 Magento Integration",
   "type": "magento2-module",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "authors": [
     {
       "name": "ImageKit Developer",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="ImageKit_ImageKitMagento" setup_version="1.0.1" schema_version="1.0.1" />
+	<module name="ImageKit_ImageKitMagento" setup_version="1.0.2" schema_version="1.0.2" />
 </config>

--- a/view/adminhtml/templates/catalog/product/helper/gallery.phtml
+++ b/view/adminhtml/templates/catalog/product/helper/gallery.phtml
@@ -40,7 +40,7 @@ $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode():
      data-mage-init='{"openVideoModal":{}}'
      data-parent-component="<?= $block->escapeHtml($block->getData('config/parentComponent')) ?>"
      data-images="<?= $block->escapeHtmlAttr($block->getImagesJson()) ?>"
-     data-types='<?= /* @noEscape */ $jsonHelper->jsonEncode($block->getImageTypes()) ?>'
+     data-types='<?= /* @noEscape */ $jsonHelper ? $jsonHelper->jsonEncode($block->getImageTypes()): json_encode($block->getImageTypes()) ?>'
 >
     <?php if ($block->getUploaderUrl() !== null) { ?>
         <div class="image image-placeholder" onclick='jQuery(".ik-ml-gallery-modal").trigger("openModal");'>
@@ -319,11 +319,32 @@ $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode():
             </div>
         </div>
     </div>
-    <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-        'display:none',
-        'div#' . $videoBlockId
-    ) ?>
+
+    <?php if (isset($secureRenderer)): ?>
+
+        <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
+            'display:none',
+            'div#' . $videoBlockId
+        ) ?>
+
+    <?php else: ?>
+
+        <style type="text/css">
+            <?php echo 'div#' . $videoBlockId ?> {
+                display:none
+            }
+        </style>
+
+    <?php endif; ?>
+    
 
     <?= $block->getChildHtml('new-video') ?>
 </div>
-<?= /* @noEscape */ $secureRenderer->renderTag('script', [], "jQuery('body').trigger('contentUpdated');", false) ?>
+
+<?php if (isset($secureRenderer)): ?>
+    <?php /* @noEscape */ $secureRenderer->renderTag('script', [], "jQuery('body').trigger('contentUpdated');", false) ?>
+<?php else: ?>
+    <script type="text/javascript">
+        jQuery('body').trigger('contentUpdated');
+    </script>
+<?php endif; ?>


### PR DESCRIPTION
RFC: `Magento\Framework\View\Helper\SecureHtmlRenderer` and `Magento\Framework\Json\Helper\Data` are not available in Magento 2.3.x
