### PR TITLE
fix: guard against null image path in Plugin/Helper/Image.php

### DIFF
--- a/Plugin/Helper/Image.php
+++ b/Plugin/Helper/Image.php
@@ -62,6 +62,7 @@ class Image
         }
 
         $imagePath = $this->imageFile ?: $this->product->getData($helper->getType());
+        $imagePath = $imagePath ?? '';
         $imagePath = ltrim($imagePath, '/');
         $imagePath = preg_replace('#^media/#', '', $imagePath);
         $imagePath = preg_replace('#^catalog/product/#', '', $imagePath);


### PR DESCRIPTION
Add null coalescing fallback before ltrim() to prevent a PHP 8.3 deprecation error when a product has no image on the filesystem.

Fixes #18